### PR TITLE
peng/json md careers

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -38,7 +38,8 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.vue', '.json'],
     alias: {
-      '@': resolve('src')
+      '@': resolve('src'),
+      variables: resolve('src/styles/variables.styl')
     }
   },
   module: {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "toc": "doctoc --title '**Table of Contents**' content/en-US/FAQ.md"
   },
   "dependencies": {
+    "axios": "^0.17.1",
     "doctoc": "^1.3.0",
     "node-zopfli": "^2.0.2",
     "pug": "^2.0.0-rc.2",

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -1,6 +1,6 @@
 <template >
   <div class="footer">
-    &copy; 2017 All In Bits, Inc.
+    &copy; {{ new Date().getFullYear() }} All In Bits, Inc.
   </div>
 </template>
 
@@ -11,7 +11,7 @@ export default {
 </script>
 
 <style scoped lang="stylus">
-@require '../styles/variables.styl'
+@require '~variables'
 
 .footer
   height 3rem

--- a/src/components/Career/CardCareer.vue
+++ b/src/components/Career/CardCareer.vue
@@ -1,11 +1,6 @@
 <template>
   <router-link :class="cssClass" :to="url">
     <div class="title">{{ career.title }}</div>
-    <div class="locations">
-      <div class="location" v-for="l in career.locations">
-        {{ l }}
-      </div>
-    </div>
   </router-link>
 </template>
 
@@ -14,7 +9,7 @@ export default {
   name: 'card-career',
   computed: {
     url () {
-      return '/careers/' + this.career.id
+      return '/careers/' + this.career.slug
     },
     cssClass () {
       let value = 'card-career'
@@ -26,8 +21,8 @@ export default {
 }
 </script>
 
-<style scoped lang="stylus">
-@require '../../styles/variables.styl'
+<style lang="stylus">
+@require '~variables'
 
 .card-career + .card-career
   border-top none

--- a/src/components/Career/PageCareersEntry.vue
+++ b/src/components/Career/PageCareersEntry.vue
@@ -1,43 +1,14 @@
-<template>
-  <div class="page-career-entry">
-    <page-header
-      :title="career.title"
-      :subtitle="subtitle"
-      >
-    </page-header>
-    <article-body>
-      <div v-if="career.description" v-html="markdownBlock(career.description)"></div>
-      <template v-if="career.requirements.length > 0">
-        <h2>We're looking for someone with&hellip;</h2>
-        <ul>
-          <li v-for="req in career.requirements" v-html="markdown(req)"></li>
-        </ul>
-      </template>
-      <h2>You should be located near:</h2>
-      <ul>
-        <li v-for="loc in career.locations" v-html="markdown(loc)"></li>
-      </ul>
-      <h2>You'll help us:</h2>
-      <ul>
-        <li v-for="task in career.tasks" v-html="markdown(task)"></li>
-      </ul>
-      <h2>We'll offer:</h2>
-      <ul>
-        <li>Competitive salary</li>
-        <li>Flexible hours (part-time or full-time)</li>
-        <li>Stock options</li>
-        <li>Medical, dental, and vision insurance</li>
-        <li>An environment with plenty of opportunities to learn and innovate</li>
-        <li>Exposure to cutting-edge blockchain technology</li>
-        <li>Potential to work remotely later on</li>
-        <li>And much more&hellip;</li>
-      </ul>
-      <h2>Get in touch</h2>
-      <p v-if="career.contact" v-html="markdownBlock(career.contact)"></p>
-      <p v-else>Please submit a cover letter and resume to <a href="mailto:careers@tendermint.com">careers@tendermint.com</a>. Make sure to include availability dates, desired working hours per week, and preferred location.  We'll write back as soon as we can.</p>
-      <btn type="anchor" size="lg" href="mailto:careers@tendermint.com" icon="envelope-o" value="Send Application"></btn>
-    </article-body>
-  </div>
+<template lang="pug">
+.page-career-entry
+  page-header(:title='career.title' :subtitle='subtitle')
+  article-body
+    div(v-html="markdown(career.body)")
+    btn(
+      type='anchor'
+      size='lg'
+      href='mailto:careers@tendermint.com'
+      icon='envelope-o'
+      value='Send Application')
 </template>
 
 <script>
@@ -46,7 +17,6 @@ import ArticleBody from '@nylira/vue-article-body'
 import { mapGetters } from 'vuex'
 import MarkdownIt from 'markdown-it'
 import Btn from '@nylira/vue-button'
-let md = new MarkdownIt()
 export default {
   name: 'page-career-entry',
   components: {
@@ -55,28 +25,23 @@ export default {
     ArticleBody
   },
   computed: {
-    subtitle () {
-      return this.capitalize(this.career.area) + ' Position at Tendermint'
-    },
+    ...mapGetters(['allCareers']),
     career () {
       if (this.allCareers) {
-        return this.allCareers.find(c => c.id === this.$route.params.entry)
+        return this.allCareers.find(c => c.slug === this.$route.params.entry)
       }
-      return {
-        title: 'Loading...',
-        subtitle: 'Loading...'
-      }
+      return { title: 'Loading...', subtitle: 'Loading...' }
     },
-    ...mapGetters(['allCareers'])
+    subtitle () {
+      return this.capitalize(this.career.area) + ' Position at All In Bits'
+    }
   },
   methods: {
     capitalize (string) {
       return string.charAt(0).toUpperCase() + string.slice(1)
     },
     markdown (text) {
-      return md.renderInline(text)
-    },
-    markdownBlock (text) {
+      let md = new MarkdownIt()
       return md.render(text)
     },
     email (address) {
@@ -84,14 +49,14 @@ export default {
     }
   },
   mounted () {
-    document.title = this.career.title + ' - Careers - Tendermint'
+    document.title = this.career.title + ' - Careers - All In Bits'
   }
 }
 </script>
 
 
-<style  scoped  lang="stylus">
-@require '../../styles/variables.styl'
+<style lang="stylus">
+@require '~variables'
 
 .page-career-entry
   .tags

--- a/src/components/Career/PageCareersIndex.vue
+++ b/src/components/Career/PageCareersIndex.vue
@@ -1,30 +1,27 @@
-<template>
-  <page-split class="page-careers-index">
-    <page-header
-      title="Careers"
-      subtitle="Join us at All In Bits to build and improve <a href='https://cosmos.network'>Cosmos</a> and Tendermint.<br><br>Jobs here are constantly updated. If your specialty is unlisted, we encourage you to still apply."
-      type="split"
-      slot="header">
-    </page-header>
-    <ni-section v-if="technical.length > 0">
-      <div slot="title">Technical Positions</div>
-      <card-career v-for="c in technical" :key="c.id" :career="c"></card-career>
-    </ni-section>
-    <ni-section v-if="operations.length > 0">
-      <div slot="title">Operations Positions</div>
-      <card-career v-for="c in operations" :key="c.id" :career="c"></card-career>
-    </ni-section>
-    <ni-section v-if="community.length > 0">
-      <div slot="title">Community Positions</div>
-      <card-career v-for="c in community" :key="c.id" :career="c"></card-career>
-    </ni-section>
-  </page-split>
+<template lang="pug">
+page-split.page-careers-index
+  page-header(
+    title='Careers'
+    subtitle="Join us at All In Bits to build and improve <a href='https://cosmos.network'>Cosmos</a> and Tendermint.<br><br>Jobs here are constantly updated. If your specialty is unlisted, we encourage you to still apply."
+    type='split'
+    slot='header')
+
+  ni-section(v-if='technical.length > 0')
+    div(slot='title') Technical Positions
+    card-career(v-for='c in technical', :key='c.id', :career='c')
+
+  ni-section(v-if='operations.length > 0')
+    div(slot='title') Operations Positions
+    card-career(v-for='c in operations', :key='c.id', :career='c')
+
+  ni-section(v-if='community.length > 0')
+    div(slot='title') Community Positions
+    card-career(v-for='c in community', :key='c.id', :career='c')
 </template>
 
 <script>
-
 import { mapGetters } from 'vuex'
-import { union, orderBy } from 'lodash'
+import { orderBy } from 'lodash'
 import CardCareer from './CardCareer'
 import NiSection from '../NiSection'
 import PageHeader from '@nylira/vue-page-header'
@@ -38,52 +35,30 @@ export default {
     PageSplit
   },
   computed: {
-    tags () {
-      let tags = []
-      this.careers.map(function (career) {
-        tags = union(tags, career.tags)
-      })
-      return tags
-    },
     technical () {
-      return this.careers.filter(c => c.area === 'technical' && c.weight !== 0)
+      return this.careers.filter(c => c.area === 'technical')
     },
     operations () {
-      return this.careers.filter(c => c.area === 'operations' && c.weight !== 0)
+      return this.careers.filter(c => c.area === 'operations')
     },
     community () {
-      return this.careers.filter(c => c.area === 'community' && c.weight !== 0)
+      return this.careers.filter(c => c.area === 'community')
     },
     careers () {
       let orderedCareers = orderBy(this.allCareers, ['title'], ['asc'])
       return orderedCareers
-
-      /*
-      let activeTag = this.activeTag
-
-      if (activeTag === 'all') {
-        return orderedCareers
-      } else {
-        return orderedCareers.filter(career => career.tags.includes(activeTag))
-      }
-      */
     },
     ...mapGetters(['allCareers'])
   },
-  data () {
-    return {
-      activeTag: 'all'
-    }
-  },
   mounted () {
-    document.title = 'Careers - All In Bits, Inc.'
+    document.title = 'Careers - All In Bits'
   }
 }
 </script>
 
 
-<style scoped lang="stylus">
-@require '../../styles/variables.styl'
+<style lang="stylus">
+@require '~variables'
 
 .page-careers-index
   .tags

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,7 +19,7 @@ const routes = [
   { path: '/careers/ethereum-developer', redirect: '/careers/developer-ethereum' },
   { path: '/careers/p2p-networking-engineer', redirect: '/careers/developer-p2p' },
   { path: '/careers/ops-office-manager', redirect: '/careers/office-manager-sf' },
-  { path: '/careers/berlin-office-manager', redirect: '/careers/office-manager-berlin' },
+  { path: '/careers/berlin-office-manager', redirect: '/careers/office-manager-berlin' }
 ]
 
 const router = new VueRouter({

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,7 +9,17 @@ const routes = [
   { path: '/about', name: 'about', component: About },
   { path: '/offices', component: Offices },
   { path: '/careers', component: CareersIndex },
-  { path: '/careers/:entry', component: CareersEntry }
+  { path: '/careers/:entry', component: CareersEntry },
+
+  // redirect old JSON Career urls to new Markdown Career urls
+  { path: '/careers/networking-consensus-engineer',
+    redirect: '/careers/developer-consensus' },
+  { path: '/careers/apps-developer', redirect: '/careers/developer-cosmos' },
+  { path: '/careers/devops-sysops-engineer', redirect: '/careers/developer-devops' },
+  { path: '/careers/ethereum-developer', redirect: '/careers/developer-ethereum' },
+  { path: '/careers/p2p-networking-engineer', redirect: '/careers/developer-p2p' },
+  { path: '/careers/ops-office-manager', redirect: '/careers/office-manager-sf' },
+  { path: '/careers/berlin-office-manager', redirect: '/careers/office-manager-berlin' },
 ]
 
 const router = new VueRouter({

--- a/src/store/modules/careers.js
+++ b/src/store/modules/careers.js
@@ -1,8 +1,67 @@
-let url = 'https://raw.githubusercontent.com/tendermint/aib-data/master/json/careers.json'
+import axios from 'axios'
 
-fetch(url)
-  .then(response => response.json())
-  .then(json => (state.all = json))
+let prefix = 'https://api.github.com/repos/tendermint/aib-data/contents/'
+let careerUrl = prefix + 'md/careers'
 
-const state = { all: '' }
-export default { state }
+async function getFiles (careerDirectory) {
+  return Promise.all(careerDirectory.map(c => {
+    let url = prefix + c.path
+    return getFile(url)
+  }))
+}
+
+async function getFile (url) {
+  return (await axios.get(url)).data
+}
+
+function addSlug (file) {
+  let slug = file.name.split('.')[0]
+  slug = slug.split('-')
+  slug.shift()
+  slug = slug.join('-')
+  file.slug = slug
+  return file
+}
+
+function addArea (file) {
+  file.area = file.name.split('-')[0]
+  return file
+}
+
+function addTitle (file) {
+  let body = window.atob(file.content)
+  let title = body.split('\n')[0]
+  let titleArray = title.split(' ')
+  titleArray.shift()
+  title = titleArray.join(' ')
+  file.title = title
+  return file
+}
+
+function addBody (file) {
+  let body = window.atob(file.content)
+  body = body.split('\n')
+  body.shift()
+  file.body = body.join('\n')
+  return file
+}
+
+async function getCareers (url) {
+  let dir = (await axios.get(careerUrl)).data
+  let careers = await getFiles(dir)
+  careers.map(c => addSlug(c))
+  careers.map(c => addArea(c))
+  careers.map(c => addTitle(c))
+  careers.map(c => addBody(c))
+  state.all = careers
+  return careers
+}
+
+getCareers()
+
+const state = {
+  all: []
+}
+const mutations = {}
+
+export default { state, mutations }

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,6 +287,13 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axios@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.17.1.tgz#2d8e3e5d0bdbd7327f91bc814f5c57660f81824d"
+  dependencies:
+    follow-redirects "^1.2.5"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -1672,7 +1679,7 @@ de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
 
-debug@*:
+debug@*, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -2389,6 +2396,12 @@ flat-cache@^1.2.1:
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
+follow-redirects@^1.2.5:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.4.1.tgz#d8120f4518190f55aac65bb6fc7b85fcd666d6aa"
+  dependencies:
+    debug "^3.1.0"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This PR switches the data used for job listings from `aib-data/json/careers.json` to [`aib-data/md/careers`](https://github.com/tendermint/aib-data/tree/develop/md/careers). Using markdown files for careers allows for far more flexibility in communicating to potential hires. It's also easier for non-developers to edit.

Note: The old job urls will redirect to the new job urls.